### PR TITLE
Change tester config to run head instead of tail for RISC-V

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ The base cmake setup for SCalc assignment.
 
 Author: Braedy Kuzma (braedy@ualberta.ca)  
 Updated by: Deric Cheung (dacheung@ualberta.ca)
+Updated by: Quinn Pham (qpham@ualberta.ca)
 
 # Usage
 ## Building

--- a/tests/SCalcConfigCS.json
+++ b/tests/SCalcConfigCS.json
@@ -17,32 +17,31 @@
         "output": "interpreterOut"
       }
     ],
-    "risc": [
+    "riscv": [
       {
-        "stepName": "scalc-RISC",
+        "stepName": "scalc-RISCV",
         "executablePath": "$EXE",
         "arguments": [
-          "risc",
+          "riscv",
           "$INPUT",
           "$OUTPUT"
           ],
-        "output": "riscOut.s"
+        "output": "riscvOut.s"
       },
       {
         "stepName": "rars",
         "executablePath": "/usr/local/bin/rars",
         "arguments": [
-          "-file",
           "$INPUT"
         ],
         "output": "-"
       },
       {
-        "stepName": "tail",
-        "executablePath": "/usr/bin/tail",
+        "stepName": "head",
+        "executablePath": "/usr/bin/head",
         "arguments": [
           "-n",
-          "+6",
+          "-2",
           "$INPUT"
         ],
         "output": "-"


### PR DESCRIPTION
When running rars, we want to trim the last 2 lines of the output (they are garbage).